### PR TITLE
Fix workflow sync-gh-pages

### DIFF
--- a/.github/workflows/sync-gh-pages.yml
+++ b/.github/workflows/sync-gh-pages.yml
@@ -13,9 +13,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: gh-pages
+          fetch-depth: 0
 
       - name: Merge master
         run: |
           git remote update --prune
-          git -c user.name='auto commit' -c user.email='noreply@localhost' merge origin/master --no-edit
+          git -c user.name='auto commit' -c user.email='noreply@localhost' merge origin/master --no-edit -s ours 
           git push


### PR DESCRIPTION
- Use merge-strategy: ours to ignore conflicts

FIXME
- Fetch all commits when checkout, so gh-pages and master have shared
  parent commit on runner (So it can do merge).
- This way is not elegant and may takes more and more time with
  increasing git log, should be fixed later